### PR TITLE
Solved: Encoding::UndefinedConversionError

### DIFF
--- a/lib/file_convert/conversion.rb
+++ b/lib/file_convert/conversion.rb
@@ -36,7 +36,7 @@ module FileConvert
     #
     # @return [FileConvert::Conversion]
     def save(target_path)
-      ::File.open(target_path, 'w') { |file| file.write(@file.body) }
+      ::File.open(target_path, 'wb') { |file| file.write(@file.body) }
     end
 
     private


### PR DESCRIPTION
To fix the conversion of document files(doc, xls etc.) to PDFs

```
Encoding::UndefinedConversionError - "\xBF" from ASCII-8BIT to UTF-8:
  file-convert (0.2.0) lib/file_convert/conversion.rb:38:in `block in save'
  file-convert (0.2.0) lib/file_convert/conversion.rb:38:in `save'
```
